### PR TITLE
Add handler to check ownership of repo or org

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,8 @@ const createGraphqlRequest = require('./endpoints/graphql').createRequest
 const createNotifyRequest = require('./endpoints/notify').createRequest
 const createTwitterPostRequest = require('./endpoints/twitter-post').createRequest
 const createTwitterFollowersRequest = require('./endpoints/twitter-followers').createRequest
+const createCheckOwnershipRequest = require('./endpoints/check-ownership').createRequest
+
 
 const express = require('express')
 const bodyParser = require('body-parser')
@@ -55,6 +57,14 @@ app.post('/twitter-post', (req, res) => {
 app.post('/twitter-followers', (req, res) => {
   console.log('POST Data: ', req.body)
   createTwitterFollowersRequest(req.body, (status, result) => {
+    console.log('Result: ', result)
+    res.status(status).json(result)
+  })
+})
+
+app.post('/check-ownership', (req, res) => {
+  console.log('POST Data: ', req.body)
+  createCheckOwnershipRequest(req.body, (status, result) => {
     console.log('Result: ', result)
     res.status(status).json(result)
   })

--- a/bridges/check-ownership.json
+++ b/bridges/check-ownership.json
@@ -1,0 +1,1 @@
+{ "name": "check-ownership", "url": "http://localhost:8080/check-ownership" }

--- a/endpoints/check-ownership.js
+++ b/endpoints/check-ownership.js
@@ -99,7 +99,7 @@ const createRequest = (input, callback) => {
         const ownerType = nodeType == "Repository" ? response.data.node.owner.__typename : null
 
         if (nodeType == "Repository" && ownerType == "User") {
-          const result = response.data.node.owner.id == githubUserId ? "true" : "false"
+          const result = response.data.node.owner.id == githubUserId ? true : false
           callback(response.status, Requester.success(jobRunID, {data: {result: result}}))
         } else {
           const orgLogin = nodeType == "Organization" ? reponse.data.node.login : response.data.node.owner.login
@@ -111,7 +111,7 @@ const createRequest = (input, callback) => {
               if (response.data.node.__typename != "User") {
                 callback(500, Requester.errored(jobRunID, { checkOwnershipError: `Node (${githubUserId}) is not a User.` }))
               } else {
-                const result = response.data.node.organization ? "true" : "false"
+                const result = response.data.node.organization ? true : false
                 callback(response.status, Requester.success(jobRunID, {data: {result: result}}))
               }      
             })

--- a/endpoints/check-ownership.js
+++ b/endpoints/check-ownership.js
@@ -1,0 +1,161 @@
+require('dotenv').config()
+const { Requester, Validator } = require('@chainlink/external-adapter')
+
+// Define custom error scenarios for the API.
+// Return true for the adapter to retry.
+const customError = (data) => {
+  if (data.Response === 'Error') return true
+  return false
+}
+
+// Define custom parameters to be used by the adapter.
+// Extra parameters can be stated in the extra object,
+// with a Boolean value indicating whether or not they
+// should be required.
+const customParams = {
+  githubUserId: ['githubUserId'],
+  repoOrgId: ['repoOrgId']
+}
+
+const createRequest = (input, callback) => {
+  // The Validator helps you validate the Chainlink request data
+  const validator = new Validator(callback, input, customParams)
+  const jobRunID = validator.validated.id
+  const url = 'https://api.github.com/graphql'
+  const githubUserId = validator.validated.data.githubUserId
+  const repoOrgId = validator.validated.data.repoOrgId
+
+  const headers = {
+    Authorization: 'bearer ' + process.env.GITHUB_PERSONAL_ACCESS_TOKEN
+  }
+
+  // Check if node ID for repoOrgId is a repo or org
+  const checkRepoOrOrg = {
+    url,
+    headers,
+    method: 'POST',
+    data: {
+      query: `query($repoOrgId:ID!) { 
+        node(id: $repoOrgId) {
+           __typename
+           ... on Organization {
+               login
+           }
+           ... on Repository {
+               owner {
+                   __typename
+                   ... on Organization {
+                       login
+                   }
+                   ... on User {
+                       id
+                   }
+               }
+           }
+        }
+      }`,
+      variables: {
+        repoOrgId
+      }
+    }
+  }
+
+  // Check if user is a member of a given organization
+  const checkUserMember = (orgLogin) => {
+    return {
+      url,
+      headers,
+      method: 'POST',
+      data: {
+        query: `query($githubUserId:ID!, $orgLogin:String!) { 
+          node(id: $githubUserId) {
+            __typename
+            ... on User {
+                organization(login: $orgLogin) {
+                    id
+                }
+            }
+          }
+        }`,
+        variables: {
+          githubUserId,
+          orgLogin
+        }
+      }
+    }
+  }
+
+  // The Requester allows API calls be retry in case of timeout
+  // or connection failure
+  Requester.request(checkRepoOrOrg, customError)
+    .then(response => {
+      // remove redundant object node
+      response.data = response.data.data
+
+      const nodeType = response.data.node.__typename
+      if (nodeType != "Repository" && nodeType != "Organization") {
+        callback(500, Requester.errored(jobRunID, { checkOwnershipError: `Node (${repoOrgId}) is not a Repository or Organization.` }))
+      } else {
+        const ownerType = nodeType == "Repository" ? response.data.node.owner.__typename : null
+
+        if (nodeType == "Repository" && ownerType == "User") {
+          const result = response.data.node.owner.id == githubUserId ? "true" : "false"
+          callback(response.status, Requester.success(jobRunID, {data: {result: result}}))
+        } else {
+          const orgLogin = nodeType == "Organization" ? reponse.data.node.login : response.data.node.owner.login
+          Requester.request(checkUserMember(orgLogin), customError)
+            .then(response => {
+              // remove redundant object node
+              response.data = response.data.data
+        
+              if (response.data.node.__typename != "User") {
+                callback(500, Requester.errored(jobRunID, { checkOwnershipError: `Node (${githubUserId}) is not a User.` }))
+              } else {
+                const result = response.data.node.organization ? "true" : "false"
+                callback(response.status, Requester.success(jobRunID, {data: {result: result}}))
+              }      
+            })
+            .catch(error => {
+              console.log(error)
+              callback(500, Requester.errored(jobRunID, JSON.stringify(error)))
+            })            
+        }
+      }
+    })
+    .catch(error => {
+      console.log(error)
+      callback(500, Requester.errored(jobRunID, JSON.stringify(error)))
+    })
+}
+
+// This is a wrapper to allow the function to work with
+// GCP Functions
+exports.gcpservice = (req, res) => {
+  createRequest(req.body, (statusCode, data) => {
+    res.status(statusCode).send(data)
+  })
+}
+
+// This is a wrapper to allow the function to work with
+// AWS Lambda
+exports.handler = (event, context, callback) => {
+  createRequest(event, (statusCode, data) => {
+    callback(null, data)
+  })
+}
+
+// This is a wrapper to allow the function to work with
+// newer AWS Lambda implementations
+exports.handlerv2 = (event, context, callback) => {
+  createRequest(JSON.parse(event.body), (statusCode, data) => {
+    callback(null, {
+      statusCode: statusCode,
+      body: JSON.stringify(data),
+      isBase64Encoded: false
+    })
+  })
+}
+
+// This allows the function to be exported for testing
+// or for running in express
+module.exports.createRequest = createRequest

--- a/jobs/check-ownership.json
+++ b/jobs/check-ownership.json
@@ -1,0 +1,16 @@
+{
+  "name": "Check Org or Repo Ownership",
+  "initiators": [
+    {
+      "type": "runlog",
+      "params": {
+        "address": "YOUR_ORACLE_CONTRACT_ADDRESS"
+      }
+    }
+  ],
+  "tasks": [
+    { "type": "check-ownership" },
+    { "type": "ethbytes32" },
+    { "type": "ethtx" }
+  ]
+}

--- a/jobs/check-ownership.json
+++ b/jobs/check-ownership.json
@@ -10,7 +10,7 @@
   ],
   "tasks": [
     { "type": "check-ownership" },
-    { "type": "ethbytes32" },
+    { "type": "ethbool" },
     { "type": "ethtx" }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@chainlink/external-adapter": "^0.2.3",
-    "@octobay/adapters": "^0.0.4",
+    "@octobay/adapters": "^0.0.9",
     "dotenv": "^8.2.0",
     "memory-cache": "^0.2.0",
     "truncate-utf8-bytes": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -205,10 +205,10 @@
     "@ethersproject/properties" "^5.0.7"
     "@ethersproject/strings" "^5.0.8"
 
-"@octobay/adapters@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@octobay/adapters/-/adapters-0.0.4.tgz#5b831f69488bda525f859ad1c2b1f2a9555fbe09"
-  integrity sha512-QsOnNLZZHyEUMdksuroyGcCrQ3+W88URiVWQp6cj6f2dTH0DU+hLuj0ilWjVr/LHKSnEcqLj1udwKzd1G8I47Q==
+"@octobay/adapters@^0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@octobay/adapters/-/adapters-0.0.9.tgz#32a36b2e0444ed477892cf0226d5d8f2845a064e"
+  integrity sha512-y/bZU8zwr/qAfl2Fb4EX24qqhLKTpWu2t/VC1ieD4ERdISmuqxJUT3QiawigcMDwkCVAaczl/s+jqOlmlKPHng==
   dependencies:
     axios "^0.21.1"
     axios-retry "^3.1.9"


### PR DESCRIPTION
This PR covers: #10 

Given a Github user ID and an ID for a Repository or Organization, the new handler checks whether the user is either:
* The owner of the Repository itself
* A member of the Organization given
* A member of the Organization which owns the Repository

The result is simply a "true" or "false" string for now, but we can obviously add more info in the response object if needed.

NOTE: We're only checking membership in the Organization for now as you need to be a member of an Organization to see what everyone's roles are. Hoping to fix this later.

Also, the version on the `@octobay/adapters` lib was old and things were sort of breaking, so this was updated.